### PR TITLE
Kurinji but replaces string usage with generics

### DIFF
--- a/src/action_event.rs
+++ b/src/action_event.rs
@@ -1,4 +1,4 @@
-use crate::Kurinji;
+use crate::{Kurinji, Actionable};
 
 use bevy::app::Events;
 use bevy::ecs::{Res, ResMut};
@@ -6,38 +6,38 @@ use bevy::ecs::{Res, ResMut};
 /// Event that is fired when action is active.
 /// This depends on what event phase is set to
 /// the action by default it will be OnProgress.
-pub struct OnActionActive {
-    pub action: String,
+pub struct OnActionActive<T: Actionable> {
+    pub action: T,
     pub strength: f32,
 }
 
 /// Event that gets fired at the beginning
 /// of an action
-pub struct OnActionBegin {
-    pub action: String,
+pub struct OnActionBegin<T: Actionable> {
+    pub action: T,
     pub strength: f32,
 }
 
 /// Event that gets fired during
 /// an action
-pub struct OnActionProgress {
-    pub action: String,
+pub struct OnActionProgress<T: Actionable> {
+    pub action: T,
     pub strength: f32,
 }
 
 /// Event that gets fired at the end
 /// of an action
-pub struct OnActionEnd {
-    pub action: String,
+pub struct OnActionEnd<T: Actionable> {
+    pub action: T,
 }
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     pub(crate) fn action_event_producer(
-        input_map: Res<Kurinji>,
-        mut on_active_event: ResMut<Events<OnActionActive>>,
-        mut on_begin_event: ResMut<Events<OnActionBegin>>,
-        mut on_progress_event: ResMut<Events<OnActionProgress>>,
-        mut on_end_event: ResMut<Events<OnActionEnd>>,
+        input_map: Res<Kurinji<T>>,
+        mut on_active_event: ResMut<Events<OnActionActive<T>>>,
+        mut on_begin_event: ResMut<Events<OnActionBegin<T>>>,
+        mut on_progress_event: ResMut<Events<OnActionProgress<T>>>,
+        mut on_end_event: ResMut<Events<OnActionEnd<T>>>,
     ) {
         // merge keys, required for action end to be fired properly.
         // Since released actions won't be part of raw strength
@@ -49,28 +49,28 @@ impl Kurinji {
         }
 
         for (action, strength) in _actions {
-            if input_map.is_action_active(&action) {
+            if input_map.is_action_active(action) {
                 on_active_event.send(OnActionActive {
                     action: action.clone(),
                     strength: strength,
                 });
             }
 
-            if input_map.did_action_just_began(&action) {
+            if input_map.did_action_just_began(action) {
                 on_begin_event.send(OnActionBegin {
                     action: action.clone(),
                     strength: strength,
                 });
             }
 
-            if input_map.is_action_in_progress(&action) {
+            if input_map.is_action_in_progress(action) {
                 on_progress_event.send(OnActionProgress {
                     action: action.clone(),
                     strength: strength,
                 });
             }
 
-            if input_map.did_action_just_end(&action) {
+            if input_map.did_action_just_end(action) {
                 on_end_event.send(OnActionEnd {
                     action: action.clone(),
                 });

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,44 +1,44 @@
-use crate::{EventPhase, Kurinji, axis::MouseAxis, axis::GamepadAxis};
+use crate::{EventPhase, Kurinji, axis::MouseAxis, axis::GamepadAxis, Actionable};
 
 use bevy::prelude::*;
 use std::{collections::HashMap, hash::Hash};
 
 /// Data structure to hold bindings.
 #[derive(Default, Clone, Debug)]
-pub struct Bindings {
-    pub(crate) gamepad_button_bindings: HashMap<(usize, GamepadButtonType), String>,
-    pub(crate) gamepad_axis_bindings: HashMap<(usize, GamepadAxis), String>,
-    pub(crate) keyboard_key_bindings: HashMap<KeyCode, String>,
-    pub(crate) mouse_button_binding: HashMap<MouseButton, String>,
-    pub(crate) mouse_move_binding: HashMap<MouseAxis, String>,
-    pub(crate) action_deadzone: HashMap<String, f32>,
-    pub(crate) action_phase: HashMap<String, EventPhase>,
+pub struct Bindings<T: Actionable> {
+    pub(crate) gamepad_button_bindings: HashMap<(usize, GamepadButtonType), T>,
+    pub(crate) gamepad_axis_bindings: HashMap<(usize, GamepadAxis), T>,
+    pub(crate) keyboard_key_bindings: HashMap<KeyCode, T>,
+    pub(crate) mouse_button_binding: HashMap<MouseButton, T>,
+    pub(crate) mouse_move_binding: HashMap<MouseAxis, T>,
+    pub(crate) action_deadzone: HashMap<T, f32>,
+    pub(crate) action_phase: HashMap<T, EventPhase>,
 }
 
-impl Bindings {
+impl<T: Actionable> Bindings<T> {
     // publics
-    pub fn merge(&mut self, bindings: Bindings) {
+    pub fn merge(&mut self, bindings: Bindings<T>) {
         // keyboard
-        self.keyboard_key_bindings = Bindings::get_merged_hashmaps(
+        self.keyboard_key_bindings = Bindings::<T>::get_merged_hashmaps(
             self.keyboard_key_bindings.clone(),
             bindings.keyboard_key_bindings,
         );
 
         // mouse
-        self.mouse_button_binding = Bindings::get_merged_hashmaps(
+        self.mouse_button_binding = Bindings::<T>::get_merged_hashmaps(
             self.mouse_button_binding.clone(),
             bindings.mouse_button_binding,
         );
-        self.mouse_move_binding = Bindings::get_merged_hashmaps(
+        self.mouse_move_binding = Bindings::<T>::get_merged_hashmaps(
             self.mouse_move_binding.clone(),
             bindings.mouse_move_binding,
         );
 
         // actions
         self.action_deadzone =
-            Bindings::get_merged_hashmaps(self.action_deadzone.clone(), bindings.action_deadzone);
+            Bindings::<T>::get_merged_hashmaps(self.action_deadzone.clone(), bindings.action_deadzone);
         self.action_phase =
-            Bindings::get_merged_hashmaps(self.action_phase.clone(), bindings.action_phase);
+            Bindings::<T>::get_merged_hashmaps(self.action_phase.clone(), bindings.action_phase);
     }
 
     // private
@@ -51,9 +51,9 @@ impl Bindings {
     }
 }
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // public
-    pub fn get_bindings(&self) -> Bindings {
+    pub fn get_bindings(&self) -> Bindings<T> {
         Bindings {
             gamepad_button_bindings: self.joystick_button_binding.clone(),
             gamepad_axis_bindings: self.joystick_axis_binding.clone(),
@@ -65,7 +65,7 @@ impl Kurinji {
             action_phase: self.action_phase.clone(),
         }
     }
-    pub fn set_bindings(&mut self, bindings: Bindings) {
+    pub fn set_bindings(&mut self, bindings: Bindings<T>) {
         self.joystick_button_binding = bindings.gamepad_button_bindings;
         self.joystick_axis_binding = bindings.gamepad_axis_bindings;
         self.keyboard_action_binding = bindings.keyboard_key_bindings;

--- a/src/event_phase.rs
+++ b/src/event_phase.rs
@@ -1,4 +1,4 @@
-use crate::Kurinji;
+use crate::{Kurinji, Actionable};
 
 use serde::{Deserialize, Serialize};
 
@@ -15,11 +15,11 @@ impl Default for EventPhase {
     }
 }
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // publics
     /// Returns in which event phase this action active will be true
-    pub fn get_event_phase(&self, action: &str) -> &EventPhase {
-        if let Some(v) = self.action_phase.get(action) {
+    pub fn get_event_phase(&self, action: T) -> &EventPhase {
+        if let Some(v) = self.action_phase.get(&action) {
             return v;
         }
 
@@ -27,24 +27,24 @@ impl Kurinji {
     }
     /// Set on which event phase should action will be true.
     /// By default will be Phase::OnProgress
-    pub fn set_event_phase(&mut self, action: &str, phase: EventPhase) -> &mut Kurinji {
-        self.action_phase.insert(action.to_string(), phase);
+    pub fn set_event_phase(&mut self, action: T, phase: EventPhase) -> &mut Kurinji<T> {
+        self.action_phase.insert(action, phase);
         self
     }
 
     // crates
-    pub(crate) fn did_action_just_began(&self, action: &str) -> bool {
+    pub(crate) fn did_action_just_began(&self, action: T) -> bool {
         self.get_prev_strength(action) == 0.0 && self.get_action_strength(action) > 0.0
     }
 
     /// Is this action happening.
     /// Note* this does not consider action event phase
     /// use is_action_active() in that case
-    pub(crate) fn is_action_in_progress(&self, action: &str) -> bool {
+    pub(crate) fn is_action_in_progress(&self, action: T) -> bool {
         self.get_action_strength(action) > 0.0
     }
 
-    pub(crate) fn did_action_just_end(&self, action: &str) -> bool {
+    pub(crate) fn did_action_just_end(&self, action: T) -> bool {
         self.get_prev_strength(action) > 0.0 && self.get_action_strength(action) == 0.0
     }
 }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,18 +1,21 @@
-use crate::kurinji::Kurinji;
+use crate::{
+    kurinji::Kurinji,
+    Actionable,
+};
 
 use bevy::prelude::KeyCode;
 use bevy::ecs::{Res, ResMut};
 use bevy::input::Input;
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // publics
-    pub fn bind_keyboard_pressed(&mut self, code: KeyCode, action: &str) -> &mut Kurinji {
+    pub fn bind_keyboard_pressed(&mut self, code: KeyCode, action: T) -> &mut Kurinji<T> {
         self.keyboard_action_binding
-            .insert(code, action.to_string());
+            .insert(code, action);
         self
     }
 
-    pub fn unbind_keyboard_pressed(&mut self, code: KeyCode) -> &mut Kurinji {
+    pub fn unbind_keyboard_pressed(&mut self, code: KeyCode) -> &mut Kurinji<T> {
         self.keyboard_action_binding.remove(&code);
         self
     }
@@ -20,7 +23,7 @@ impl Kurinji {
     // crates
     // system
     pub(crate) fn kb_key_press_input_system(
-        mut input_map: ResMut<Kurinji>,
+        mut input_map: ResMut<Kurinji<T>>,
         key_input: Res<Input<KeyCode>>,
     ) {
         // let map = &mut input_map;
@@ -28,7 +31,7 @@ impl Kurinji {
 
         for (keycode, action) in bindings_iter.iter() {
             if key_input.pressed(*keycode) {
-                input_map.set_raw_action_strength(action, 1.0);
+                input_map.set_raw_action_strength(*action, 1.0);
             }
         }
     }

--- a/src/kurinji.rs
+++ b/src/kurinji.rs
@@ -1,9 +1,9 @@
-use crate::{axis::MouseAxis, bindings::Bindings, EventPhase, GamepadAxis};
+use crate::{axis::MouseAxis, bindings::Bindings, EventPhase, GamepadAxis, Actionable};
 
 use bevy::prelude::*;
 use std::collections::{HashMap, HashSet};
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // constants
     /// Max number of players that can be connected using gamepads
     pub const MAX_PLAYER_HANDLES: usize = 8;
@@ -11,30 +11,30 @@ impl Kurinji {
 
 /// Resource to access all Kurinji APIs
 #[derive(Default, Clone)]
-pub struct Kurinji {
+pub struct Kurinji<T: Actionable> {
     // crates
     // actions
-    pub(crate) action_strength_curve: HashMap<String, fn(f32) -> f32>,
-    pub(crate) action_raw_strength: HashMap<String, f32>,
-    pub(crate) action_prev_strength: HashMap<String, f32>, // strength value from prev frame
-    pub(crate) action_deadzone: HashMap<String, f32>,
-    pub(crate) action_phase: HashMap<String, EventPhase>,
+    pub(crate) action_strength_curve: HashMap<T, fn(f32) -> f32>,
+    pub(crate) action_raw_strength: HashMap<T, f32>,
+    pub(crate) action_prev_strength: HashMap<T, f32>, // strength value from prev frame
+    pub(crate) action_deadzone: HashMap<T, f32>,
+    pub(crate) action_phase: HashMap<T, EventPhase>,
 
     // keyboard
-    pub(crate) keyboard_action_binding: HashMap<KeyCode, String>,
+    pub(crate) keyboard_action_binding: HashMap<KeyCode, T>,
 
     // mouse
-    pub(crate) mouse_button_binding: HashMap<MouseButton, String>,
-    pub(crate) mouse_move_binding: HashMap<MouseAxis, String>,
+    pub(crate) mouse_button_binding: HashMap<MouseButton, T>,
+    pub(crate) mouse_move_binding: HashMap<MouseAxis, T>,
 
     // joystick
     pub(crate) player_handles_in_use: HashSet<usize>,
     pub(crate) joystick_to_player_map: HashMap<Gamepad, usize>,
     pub(crate) player_to_joystick_map: HashMap<usize, Gamepad>,
 
-    pub(crate) joystick_button_binding: HashMap<(usize, GamepadButtonType), String>,
-    pub(crate) joystick_axis_binding: HashMap<(usize, GamepadAxis), String>,
+    pub(crate) joystick_button_binding: HashMap<(usize, GamepadButtonType), T>,
+    pub(crate) joystick_axis_binding: HashMap<(usize, GamepadAxis), T>,
 
     // stack
-    pub(crate) stack: Vec<Bindings>,
+    pub(crate) stack: Vec<Bindings<T>>,
 }

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,4 +1,4 @@
-use crate::{MouseAxis, Kurinji, util::clamp_vec2};
+use crate::{MouseAxis, Kurinji, util::clamp_vec2, Actionable};
 
 use bevy::{math::Vec2, prelude::MouseButton};
 use bevy::app::{EventReader, Events};
@@ -10,24 +10,24 @@ pub struct MouseMoveState {
     reader: EventReader<MouseMotion>,
 }
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // publics
-    pub fn bind_mouse_button_pressed(&mut self, code: MouseButton, action: &str) -> &mut Kurinji {
-        self.mouse_button_binding.insert(code, action.to_string());
+    pub fn bind_mouse_button_pressed(&mut self, code: MouseButton, action: T) -> &mut Kurinji<T> {
+        self.mouse_button_binding.insert(code, action);
         self
     }
 
-    pub fn unbind_mouse_button_pressed(&mut self, button: MouseButton) -> &mut Kurinji {
+    pub fn unbind_mouse_button_pressed(&mut self, button: MouseButton) -> &mut Kurinji<T> {
         self.mouse_button_binding.remove(&button);
         self
     }
 
-    pub fn bind_mouse_motion(&mut self, axis: MouseAxis, action: &str) -> &mut Kurinji {
-        self.mouse_move_binding.insert(axis, action.to_string());
+    pub fn bind_mouse_motion(&mut self, axis: MouseAxis, action: T) -> &mut Kurinji<T> {
+        self.mouse_move_binding.insert(axis, action);
         self
     }
 
-    pub fn unbind_mouse_motion(&mut self, axis: MouseAxis) -> &mut Kurinji {
+    pub fn unbind_mouse_motion(&mut self, axis: MouseAxis) -> &mut Kurinji<T> {
         self.mouse_move_binding.remove(&axis);
         self
     }
@@ -35,19 +35,19 @@ impl Kurinji {
     // crates
     // systems
     pub(crate) fn mouse_button_press_input_system(
-        mut input_map: ResMut<Kurinji>,
+        mut input_map: ResMut<Kurinji<T>>,
         mouse_button_input: Res<Input<MouseButton>>,
     ) {
         let button_bindings_iter = input_map.mouse_button_binding.clone();
         for (button, action) in button_bindings_iter.iter() {
             if mouse_button_input.pressed(*button) {
-                input_map.set_raw_action_strength(action, 1.0);
+                input_map.set_raw_action_strength(*action, 1.0);
             }
         }
     }
 
     pub(crate) fn mouse_move_event_system(
-        mut input_map: ResMut<Kurinji>,
+        mut input_map: ResMut<Kurinji<T>>,
         mut state: Local<MouseMoveState>,
         move_events: Res<Events<MouseMotion>>,
     ) {
@@ -65,14 +65,14 @@ impl Kurinji {
             if x > 0.0 {
                 if let Some(action) = input_map.mouse_move_binding.get(&MouseAxis::XPositive) {
                     let _action = action.clone();
-                    input_map.set_raw_action_strength(&_action, x);
+                    input_map.set_raw_action_strength(_action, x);
                 }
             }
 
             if x < 0.0 {
                 if let Some(action) = input_map.mouse_move_binding.get(&MouseAxis::XNegative) {
                     let _action = action.clone();
-                    input_map.set_raw_action_strength(&_action, x.abs());
+                    input_map.set_raw_action_strength(_action, x.abs());
                 }
             }
 
@@ -80,14 +80,14 @@ impl Kurinji {
             if y > 0.0 {
                 if let Some(action) = input_map.mouse_move_binding.get(&MouseAxis::YPositive) {
                     let _action = action.clone();
-                    input_map.set_raw_action_strength(&_action, y);
+                    input_map.set_raw_action_strength(_action, y);
                 }
             }
 
             if y < 0.0 {
                 if let Some(action) = input_map.mouse_move_binding.get(&MouseAxis::YNegative) {
                     let _action = action.clone();
-                    input_map.set_raw_action_strength(&_action, y.abs());
+                    input_map.set_raw_action_strength(_action, y.abs());
                 }
             }
         }

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -1,8 +1,8 @@
-use crate::{Bindings, Kurinji};
+use crate::{Bindings, Kurinji, Actionable};
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     /// Push bindings to stack
-    pub fn push(&mut self, bindings: Bindings) {
+    pub fn push(&mut self, bindings: Bindings<T>) {
         // store current in stack
         let current = self.get_bindings();
         self.stack.push(current);
@@ -13,7 +13,7 @@ impl Kurinji {
 
     /// Clones current bindings and pushes it with the new
     /// changes
-    pub fn push_additive(&mut self, bindings: Bindings) {
+    pub fn push_additive(&mut self, bindings: Bindings<T>) {
         // store current in stack
         let current = self.get_bindings();
         self.stack.push(current);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,24 +1,24 @@
-use crate::{GamepadAxis, Kurinji, bindings::Bindings, serde::BindingsSerdeHelper};
+use crate::{GamepadAxis, Kurinji, bindings::Bindings, serde::BindingsSerdeHelper, Actionable};
 
 use bevy::prelude::*;
 use std::{collections::HashMap, fs};
 
-impl Kurinji {
+impl<T: Actionable> Kurinji<T> {
     // publics
-    pub fn get_bindings_from_json_file(path: &str) -> Bindings {
+    pub fn get_bindings_from_json_file(path: &str) -> Bindings<T> {
         let json = fs::read_to_string(path).expect("Error! could not open bindings file");
         Kurinji::get_bindings_from_json(&json)
     }
 
-    pub fn get_bindings_from_ron_file(path: &str) -> Bindings {
+    pub fn get_bindings_from_ron_file(path: &str) -> Bindings<T> {
         let ron = fs::read_to_string(path).expect("Error! could not open bindings file");
         Kurinji::get_bindings_from_ron(&ron)
     }
 
-    pub fn get_bindings_from_json(json: &str) -> Bindings {
+    pub fn get_bindings_from_json(json: &str) -> Bindings<T> {
         serde_json::from_str(json).expect("Failed to deserialise bindings json")
     }
-    pub fn get_bindings_from_ron(ron: &str) -> Bindings {
+    pub fn get_bindings_from_ron(ron: &str) -> Bindings<T> {
         ron::de::from_str(ron).expect("Failed to deserialise bindings ron")
     }
 
@@ -66,12 +66,12 @@ impl Kurinji {
     } 
 }
 
-impl BindingsSerdeHelper {
+impl<T: Actionable> BindingsSerdeHelper<T> {
     // utils
     pub fn get_gamepad_button_hash_map_from_json_friendly_map(
-        json_map: HashMap<usize, HashMap<GamepadButtonType, String>>,
-    ) -> HashMap<(usize, GamepadButtonType), String> {
-        let mut result: HashMap<(usize, GamepadButtonType), String>  = HashMap::new();
+        json_map: HashMap<usize, HashMap<GamepadButtonType, T>>,
+    ) -> HashMap<(usize, GamepadButtonType), T> {
+        let mut result: HashMap<(usize, GamepadButtonType), T>  = HashMap::new();
         for (player, h_map) in json_map {
             for (btn_type, action) in h_map {
                 result
@@ -82,9 +82,9 @@ impl BindingsSerdeHelper {
         result
     }
     pub fn get_gamepad_axis_hash_map_from_json_friendly_map(
-        json_map: HashMap<usize, HashMap<GamepadAxis, String>>,
-    ) -> HashMap<(usize, GamepadAxis), String> {
-        let mut result: HashMap<(usize, GamepadAxis), String> = HashMap::new();
+        json_map: HashMap<usize, HashMap<GamepadAxis, T>>,
+    ) -> HashMap<(usize, GamepadAxis), T> {
+        let mut result: HashMap<(usize, GamepadAxis), T> = HashMap::new();
         for (pad_handle, h_map) in json_map {
             for (g_axis, action) in h_map {
                 result.entry((pad_handle, g_axis)).or_insert(action);
@@ -93,9 +93,9 @@ impl BindingsSerdeHelper {
         result
     }
     pub fn get_json_friendly_gamepad_button_hash_map(
-        binding: HashMap<(usize, GamepadButtonType), String>,
-    ) -> HashMap<usize, HashMap<GamepadButtonType, String>> {
-        let mut result: HashMap<usize, HashMap<GamepadButtonType, String>> = HashMap::new();
+        binding: HashMap<(usize, GamepadButtonType), T>,
+    ) -> HashMap<usize, HashMap<GamepadButtonType, T>> {
+        let mut result: HashMap<usize, HashMap<GamepadButtonType, T>> = HashMap::new();
 
         for (k, v) in binding {
             let id: usize = k.0;
@@ -108,9 +108,9 @@ impl BindingsSerdeHelper {
         result
     }
     pub fn get_json_friendly_gamepad_axis_hash_map(
-        binding: HashMap<(usize, GamepadAxis), String>,
-    ) -> HashMap<usize, HashMap<GamepadAxis, String>> {
-        let mut result: HashMap<usize, HashMap<GamepadAxis, String>> = HashMap::new();
+        binding: HashMap<(usize, GamepadAxis), T>,
+    ) -> HashMap<usize, HashMap<GamepadAxis, T>> {
+        let mut result: HashMap<usize, HashMap<GamepadAxis, T>> = HashMap::new();
 
         for (k, action) in binding {
             let id = k.0;


### PR DESCRIPTION
This way you can have multiple maps in one app and don't have to work with strings.  For instance, you can use an enum of actions so that you can have easier debugging when you type in an action wrong.