### PR TITLE
Update to bevy 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["gamedev", "bevy", "inputmap","actionmapping"]
 
 [dependencies]
 # bevy
-bevy = { version="0.4", features = ["serialize"]}
+bevy = { version="0.5", features = ["serialize"]}
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ron = "0.6.2"

--- a/example/binding_from_json.rs
+++ b/example/binding_from_json.rs
@@ -2,7 +2,7 @@ use std::fs;
 use bevy::prelude::*;
 use bevy::app::AppExit;
 use bevy::app::Events;
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 use kurinji::{Kurinji, KurinjiPlugin};
 fn main() {
     println!("Kurinji Binding From Json Example");

--- a/example/binding_gamepad_from_ron.rs
+++ b/example/binding_gamepad_from_ron.rs
@@ -2,7 +2,7 @@ use std::fs;
 use bevy::prelude::*;
 use bevy::app::AppExit;
 use bevy::app::Events;
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 use kurinji::{Kurinji, KurinjiPlugin};
 fn main() {
     println!("Kurinji Binding Gamepad From RON Example");

--- a/example/binding_gamepad_in_code.rs
+++ b/example/binding_gamepad_in_code.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::app::AppExit;
 use bevy::app::Events;
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 use kurinji::{EventPhase, GamepadAxis, Kurinji, KurinjiPlugin};
 fn main() {
     println!("Kurinji Binding Gamepad In Code Example");

--- a/example/binding_in_code.rs
+++ b/example/binding_in_code.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy::app::AppExit;
 use bevy::app::Events;
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 use kurinji::{EventPhase, MouseAxis, Kurinji, KurinjiPlugin};
 fn main() {
     println!("Kurinji Binding In Code Example");

--- a/example/example_action_events.rs
+++ b/example/example_action_events.rs
@@ -2,13 +2,8 @@ use std::fs;
 use bevy::prelude::*;
 use bevy::app::AppExit;
 use bevy::app::Events;
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 use kurinji::{OnActionActive, OnActionEnd, Kurinji, KurinjiPlugin};
-#[derive(Default)]
-pub struct ActionState {
-    active_reader: EventReader<OnActionActive>,
-    end_reader: EventReader<OnActionEnd>,
-}
 fn main() {
     println!("Kurinji Action Events");
     App::build()
@@ -26,22 +21,18 @@ fn setup(mut kurinji: ResMut<Kurinji>) {
     kurinji.set_bindings_with_json(&binding_json);
 }
 fn action_end_events_system(
-    mut state: Local<ActionState>,
+    mut state: EventReader<OnActionEnd>,
     mut app_exit_events: ResMut<Events<AppExit>>,
-    action_end_event: Res<Events<OnActionEnd>>,
 ) {
-    if let Some(value) = state.end_reader.latest(&action_end_event) {
+    for value in state.iter() {
         if value.action == "QUIT_APP" {
             println!("Quiting...");
             app_exit_events.send(AppExit);
         }
     }
 }
-fn action_active_events_system(
-    mut state: Local<ActionState>,
-    action_active_event: Res<Events<OnActionActive>>,
-) {
-    if let Some(value) = state.active_reader.latest(&action_active_event) {
+fn action_active_events_system(mut state: EventReader<OnActionActive>) {
+    for value in state.iter() {
         if value.action == "JUMP" {
             println!("Jumping...");
         }

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,5 +1,5 @@
 use crate::{EventPhase, Kurinji, util};
-use bevy::ecs::ResMut;
+use bevy::ecs::system::ResMut;
 impl Kurinji {
     // publics
     /// Provides strength of action in range 0.0 - 1.0. Useful

--- a/src/action_event.rs
+++ b/src/action_event.rs
@@ -1,6 +1,6 @@
 use crate::Kurinji;
 use bevy::app::Events;
-use bevy::ecs::{Res, ResMut};
+use bevy::ecs::system::{Res, ResMut};
 /// Event that is fired when action is active.
 /// This depends on what event phase is set to
 /// the action by default it will be OnProgress.

--- a/src/gamepad.rs
+++ b/src/gamepad.rs
@@ -1,12 +1,8 @@
 use crate::{GamepadAxis, Kurinji};
 use bevy::prelude::*;
-use bevy::app::{EventReader, Events};
-use bevy::ecs::{Local, Res, ResMut};
+use bevy::app::EventReader;
+use bevy::ecs::system::{Res, ResMut};
 use bevy::input::Input;
-#[derive(Default)]
-pub struct GamepadState {
-    reader: EventReader<GamepadEvent>,
-}
 impl Kurinji {
     // publics
     // buttons
@@ -124,10 +120,9 @@ impl Kurinji {
 
     pub(crate) fn gamepad_event_system(
         mut input_map: ResMut<Kurinji>,
-        gamepad_event: Res<Events<GamepadEvent>>,
-        mut state: Local<GamepadState>,
+        mut state: EventReader<GamepadEvent>,
     ) {
-        if let Some(value) = state.reader.latest(&gamepad_event) {
+        for value in state.iter() {
             let pad_handle = value.0;
             let pad_event_type = value.clone().1;
             match pad_event_type {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,6 +1,6 @@
 use crate::kurinji::Kurinji;
 use bevy::prelude::KeyCode;
-use bevy::ecs::{Res, ResMut};
+use bevy::ecs::system::{Res, ResMut};
 use bevy::input::Input;
 impl Kurinji {
     // publics

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,12 +1,8 @@
 use crate::{MouseAxis, Kurinji, util::clamp_vec2};
 use bevy::{math::Vec2, prelude::MouseButton};
-use bevy::app::{EventReader, Events};
-use bevy::ecs::{Local, Res, ResMut};
+use bevy::app::EventReader;
+use bevy::ecs::system::{Res, ResMut};
 use bevy::input::{mouse::MouseMotion, Input};
-#[derive(Default)]
-pub struct MouseMoveState {
-    reader: EventReader<MouseMotion>,
-}
 impl Kurinji {
     // publics
     pub fn bind_mouse_button_pressed(
@@ -56,14 +52,13 @@ impl Kurinji {
 
     pub(crate) fn mouse_move_event_system(
         mut input_map: ResMut<Kurinji>,
-        mut state: Local<MouseMoveState>,
-        move_events: Res<Events<MouseMotion>>,
+        mut state: EventReader<MouseMotion>,
     ) {
-        if let Some(value) = state.reader.latest(&move_events) {
+        for value in state.iter() {
             // normalises strength (with 10 px as max strength)
             // i.e. -10 px = -1.0 and 10 px = 1.0
-            let min = -1. * Vec2::one();
-            let max = Vec2::one();
+            let min = -1. * Vec2::ONE;
+            let max = Vec2::ONE;
             let normalised_vec = clamp_vec2(min, max, value.delta * 0.1);
             let x = normalised_vec.x;
             let y = normalised_vec.y;


### PR DESCRIPTION
Updated Kurinji to use Bevy [0.5](https://bevyengine.org/news/bevy-0-5/)

- Fixed Res and ResMut import declarations
- Transitioned Event Reading to new syntax
- Transitioned System Stages to System Sets